### PR TITLE
Added human readable time format

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,15 @@ As soon as that variable goes out of scope it automatically outputs the amount o
 
 The destination for the output over serial can be optionally specified and you can use any Arduino platform `Stream` subclass. This includes `Serial1` or `Serial2` on boards that have them, and even instances of `SoftwareSerial`, which is also `Stream` compatible. 😄 If not specified in the variable's construction then the default is the standard `Serial` device.
 
+No need of writing `digitalWrite(pin, HIGH);` and `digitalWrite(pin, LOW);` when profiling digital pins, it will be taken care of by the `profiler_t` variable! The pin will be set to high when the variable is created and set to LOW once it is destroyed / gone out of scope.
+
 Several useful constructor types define the features that are used at runtime.
 
-Updated: Now includes support for optional custom text 😎
+Updated:<br/>
+Now includes support for optional custom text 😎<br/>
+Prints out time as human readable time format (day/hour/minute/second/millisecond)
+
+**WARNING**: Recommended to profile functions that run less than a month. Max profiling time is approximately 50 days.
 
 ```cpp
 /*
@@ -27,6 +33,8 @@ Updated: Now includes support for optional custom text 😎
  *    added optional debug pin support
  * version 1.6 - August 2024
  *    added optional custom output text support
+ * version 1.7 - November 2024
+ *    added human readable time format
  *
  * The available constructors are:
  *
@@ -35,6 +43,13 @@ Updated: Now includes support for optional custom text 😎
  *    profiler_t(char const * const msg, Stream &s = Serial);
  *    profiler_t(int pin, char const * const msg, Stream &s = Serial);
  * 
+ * The available methods are:
+ *    enable();             // DEFAULT
+ *    disable();
+ * 
+ *    inReadableTime();     // DEFAULT
+ *    inMilliseconds();
+ *
  */
 
 #include <Profiler.h>
@@ -45,6 +60,9 @@ Updated: Now includes support for optional custom text 😎
 void foo();
 void bar();
 void baz();
+void disabled_example();
+void ms_example();
+void day_example();
 
 void setup() {
     Serial.begin(115200);
@@ -53,6 +71,10 @@ void setup() {
     foo();
     bar();
     baz();
+
+    disabled_example();
+    ms_example();
+    day_example();
 }
 
 void loop() {
@@ -110,12 +132,41 @@ void baz() {
     // ... some other code you want profiled
     delay(2000);
 }
+
+// Demonstration of the method "disable()"
+//
+void disabled_example() {
+    profiler_t profiler(DEBUG_LED, "This will not be printed");
+    profiler.disable();
+
+    delay(1000);
+}
+
+// Demonstration of the method "inMilliseconds()"
+//
+void ms_example() {
+    profiler_t profiler(DEBUG_LED, "This will print in milliseconds");
+    profiler.inMilliseconds();
+
+    delay(1500);
+}
+
+// Demonstration of profiling a function that takes a day
+// This example will take some time ...
+//
+void day_example() {
+    profiler_t profiler(DEBUG_LED, "Finally");
+    
+    delay(86400101);
+}
 ```
 
 output:
 
 ```console
-Time Spent: 999
-Partial Scoped Profile: 500
-Time spent in baz(): 1999
+Time Spent: 999ms
+Partial Scoped Profile: 500ms
+Time spent in baz(): 1s 999ms
+This will print in milliseconds: 1500
+Finally: 1d 0h 0m 0s 101ms
 ```

--- a/examples/Profiler/Profiler.ino
+++ b/examples/Profiler/Profiler.ino
@@ -8,6 +8,8 @@
  *    added optional debug pin support
  * version 1.6 - August 2024
  *    added optional custom output text support
+ * version 1.7 - November 2024
+ *    added human readable time format
  *
  */
 
@@ -19,6 +21,9 @@
 void foo();
 void bar();
 void baz();
+void disabled_example();
+void ms_example();
+void day_example();
 
 void setup() {
     Serial.begin(115200);
@@ -29,6 +34,10 @@ void setup() {
     bar();
 
     baz();
+
+    disabled_example();
+    ms_example();
+    day_example();
 }
 
 void loop() {
@@ -85,3 +94,29 @@ void baz() {
     delay(2000);
 }
 
+// Demonstration of the method "disable()"
+//
+void disabled_example() {
+    profiler_t profiler(DEBUG_LED, "This will not be printed");
+    profiler.disable();
+
+    delay(1000);
+}
+
+// Demonstration of the method "inMilliseconds()"
+//
+void ms_example() {
+    profiler_t profiler(DEBUG_LED, "This will print in milliseconds");
+    profiler.inMilliseconds();
+
+    delay(1500);
+}
+
+// Demonstration of profiling a function that takes a day
+// This example will take some time ...
+//
+void day_example() {
+    profiler_t profiler(DEBUG_LED, "Finally");
+    
+    delay(86400101);
+}

--- a/src/Profiler.cpp
+++ b/src/Profiler.cpp
@@ -13,15 +13,23 @@
 
 #include "Profiler.h"
 
-// static class-wide variable to control whether the output is enabled
+#define ONE_SECOND 1000
+#define ONE_MINUTE 60
+#define ONE_HOUR 60
+#define ONE_DAY 24
+
+// static class-wide variables to control whether the output is enabled and prints in milliseconds
 // 
 uint8_t profiler_t::enabled = true;
+uint8_t profiler_t::milliseconds = false;
 
+// PROFILER_T
 // class constructor
 // 
 profiler_t::profiler_t(Stream &s) {
     stream = &s;
     enabled = true;
+    milliseconds = false;
     pin = -1;
     start = millis();
 }
@@ -30,6 +38,7 @@ profiler_t::profiler_t(Stream &s) {
 profiler_t::profiler_t(int Pin, Stream &s /* = Serial */) {
     stream = &s;
     enabled = true;
+    milliseconds = false;
     start = millis();
     pin = Pin;
     if (pin >= 0) {
@@ -42,6 +51,7 @@ profiler_t::profiler_t(int Pin, Stream &s /* = Serial */) {
 profiler_t::profiler_t(char const * const msg, Stream &s /* = Serial */) {
     stream = &s;
     enabled = true;
+    milliseconds = false;
     start = millis();
     if (nullptr != msg) {
         text = msg;
@@ -52,6 +62,7 @@ profiler_t::profiler_t(char const * const msg, Stream &s /* = Serial */) {
 profiler_t::profiler_t(int Pin, char const * const msg, Stream &s /* = Serial */) {
     stream = &s;
     enabled = true;
+    milliseconds = false;
     start = millis();
     pin = Pin;
     if (nullptr != msg) {
@@ -78,7 +89,11 @@ profiler_t::~profiler_t() {
             text = "Time Spent: ";
         }
         (*stream).print(text);
-        (*stream).println(total);
+
+        if (!milliseconds)
+            ReadableTime(total, stream);
+        else
+            (*stream).println(total);
     }
 }
 
@@ -92,4 +107,81 @@ void profiler_t::enable() {
 // 
 void profiler_t::disable() {
     enabled = false;
+}
+
+// method to enable time printing in human readable time format
+//
+void profiler_t::inReadableTime() {
+    milliseconds = false;
+}
+
+// method to enable time printing in milliseconds only
+//
+void profiler_t::inMilliseconds() {
+    milliseconds = true;
+}
+
+// READABLETIME
+// class constructor
+//
+ReadableTime::ReadableTime(unsigned long total_time, Stream *s) {
+    day = 0;
+    hour = 0;
+    minute = 0;
+    second = 0;
+    stream = s;
+    
+    // max total_time value is 4,294,967,295 (4 bytes), translates to "49d 17h 2m 47s 295ms"
+    // https://docs.arduino.cc/language-reference/en/variables/data-types/unsignedLong/
+    millisecond = (uint16_t) (total_time % ONE_SECOND);
+    total_time = total_time / ONE_SECOND;
+    
+    if (total_time == 0) {
+        goto nomoretime;
+    }
+    second = (uint8_t) (total_time % ONE_MINUTE);
+    total_time = total_time / ONE_MINUTE;
+
+    if (total_time == 0) {
+        goto nomoretime;
+    }
+    minute = (uint8_t) (total_time % ONE_HOUR);
+    total_time = total_time / ONE_HOUR;
+
+    if (total_time == 0) {
+        goto nomoretime;
+    }
+    hour = (uint8_t) (total_time % ONE_DAY);
+    day = (uint8_t) (total_time / ONE_DAY);
+nomoretime:;
+}
+
+// class destructor
+//
+ReadableTime::~ReadableTime() {
+    if (day > 0)
+        goto day;
+    if (hour > 0)
+        goto hr;
+    if (minute > 0)
+        goto min;
+    if (second > 0)
+        goto sec;
+    goto ms;
+
+day:
+    (*stream).print(day);
+    (*stream).print("d ");
+hr:
+    (*stream).print(hour);
+    (*stream).print("h ");
+min:
+    (*stream).print(minute);
+    (*stream).print("m ");
+sec:
+    (*stream).print(second);
+    (*stream).print("s ");
+ms:
+    (*stream).print(millisecond);
+    (*stream).println("ms");
 }

--- a/src/Profiler.h
+++ b/src/Profiler.h
@@ -8,6 +8,8 @@
  *    added optional debug pin support
  * version 1.6 - August 2024
  *    added text support
+ * version 1.7 - November 2024
+ *    added human readable time format
  * 
  */
 #ifndef   PROFILER_H_INCL
@@ -19,6 +21,7 @@
 
 struct profiler_t {
     static uint8_t  enabled;
+    static uint8_t  milliseconds;
     Stream         *stream;
     String          text;
     unsigned long   start;
@@ -33,6 +36,22 @@ struct profiler_t {
 
     static void enable();
     static void disable();
+
+    static void inReadableTime();
+    static void inMilliseconds();
+};
+
+class ReadableTime {
+    uint8_t         day;
+    uint8_t         hour;
+    uint8_t         minute;
+    uint8_t         second;
+    uint16_t        millisecond;
+    Stream         *stream;
+
+public:
+    ReadableTime(unsigned long total_time, Stream *s);
+    ~ReadableTime();
 };
 
 #endif // PROFILER_H_INCL


### PR DESCRIPTION
The default printed time format will be day/hour/minute/second/millisecond (Xd Xh Xm Xs Xms).
Will print from the first time unit that is not 0, starting from day.
Since unsigned long is used to hold the time difference, max time profiled will be 49d 17h 2m 47s 295ms.

- Added human readable time format, set to default.
- Added new methods to enable and disable the new time format.
- Added some functions in the example to demostrate the available methods.
